### PR TITLE
207 liked playlists displayed under the correct category

### DIFF
--- a/src/lib/components/layout/playlist.svelte
+++ b/src/lib/components/layout/playlist.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { createEventDispatcher } from 'svelte';
   import { fetchApi } from '$lib/index';
 
   export let playlist;
@@ -8,6 +9,8 @@
   let existingLikeId = initialLikeId;
 
   let profileId = 122;
+
+  const dispatch = createEventDispatcher();
 
   async function toggleLike(event) {
     event.preventDefault(); 
@@ -21,15 +24,13 @@
         profile: profileId
       });
 
-      // Directe update van de UI
       isLiked = !isLiked;
-      // Als het een nieuwe like is, krijg je een likeId
       if (response?.likeId) {
         existingLikeId = response.likeId;
       }
       
-      // Herlaad de layout (trigger opnieuw renderen)
-      playlist = { ...playlist, isLiked, likeId: existingLikeId };
+      // Dispatch een event naar de parent component
+      dispatch('likeToggle', { playlistId: playlist.id, isLiked });
     } catch (error) {
       console.error('Failed to toggle like:', error);
     }

--- a/src/routes/lessons/+page.svelte
+++ b/src/routes/lessons/+page.svelte
@@ -16,6 +16,14 @@
             behavior: 'smooth',
         });
     }
+    function handleLikeToggle(event) {
+        const { playlistId, isLiked } = event.detail;
+        data.playlists = data.playlists.map(playlist => 
+            playlist.id === playlistId 
+                ? { ...playlist, isLiked: isLiked }
+                : playlist
+        );
+    }
 
 </script>
 
@@ -75,8 +83,8 @@
     <section class="own-playlist">
         <h2>Liked playlists</h2>
         <section class="playlist-list">
-            {#each data.playlists.filter(playlist => playlist.isLiked) as playlist}
-                <Playlist {playlist} />
+            {#each data.playlists.filter(playlist => playlist.isLiked) as playlist (playlist.id)}
+                <Playlist {playlist} on:likeToggle={handleLikeToggle} />
             {/each}
         </section>
     </section>
@@ -84,8 +92,8 @@
     <section class="own-playlist suggested-playlist">
         <h2>Suggested playlists</h2>
         <section class="playlist-list">
-            {#each data.playlists.filter(playlist => !playlist.isLiked) as playlist}
-                <Playlist {playlist} />
+            {#each data.playlists.filter(playlist => !playlist.isLiked) as playlist (playlist.id)}
+                <Playlist {playlist} on:likeToggle={handleLikeToggle} />
             {/each}
         </section>
     </section>


### PR DESCRIPTION
## What does this change?

Resolves issue #1337

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Als je op de lessons-pagina een playlist uit de suggestiesectie liket, dan verplaatste de playlist zich voorheen niet meteen naar de selectie gelikete playlists. De gebruiker moest eerst de pagina herladen (ook andersom, van de gelikete naar de suggesties). Ik heb er nu voor gezorgd dat wanneer een playlist wordt geliked of unliked, de selecties automatisch worden geüpdatet, zodat de gebruiker de pagina niet steeds hoeft te herladen.
[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [x] Browser test

## Images
![image](https://github.com/user-attachments/assets/a3de7275-9921-4de6-9f12-318580485791)
![image](https://github.com/user-attachments/assets/1ff910fb-af7b-4096-be57-8479853bc6f4)

![image](https://github.com/user-attachments/assets/18316500-dd8c-403d-a063-8c62733f9678)



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review
Als de gebruiker nu een playlist uit suggesties liked wordt de lijst automatisch geüpdatet en verschijnt de gelikete playlist direct in de liked playlist selectie op de lessons pagina.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
