### PR TITLE
233 appearing seasons in story filtering

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -36,6 +36,17 @@ export async function fetchAnimals(fetch) {
         throw error;
     }
 }
+
+export async function fetchSeasons(fetch) {
+    try {
+        const seasons = await fetchCollection(fetch, 'tm_season');
+        return { seasons };
+    } catch (error) {
+        console.error('Error fetching season data:', error);
+        throw error;
+    }
+}
+
 export async function fetchAllData(fetch) {
 
     const [

--- a/src/routes/all-stories/+page.server.js
+++ b/src/routes/all-stories/+page.server.js
@@ -2,7 +2,7 @@
 /** @type {import('./$types').PageLoad} */
 export let csr = true;
 import { error } from '@sveltejs/kit';
-import { fetchAllData, mapStoriesWithDetails } from '$lib/api';
+import { fetchAllData, mapStoriesWithDetails, fetchSeasons } from '$lib/api';
 import { fetchAnimals } from '../../lib/api';
 /**
  * Loads data for the page, fetching stories, animals, and languages.
@@ -16,7 +16,7 @@ import { fetchAnimals } from '../../lib/api';
  */
 export async function load({ fetch }) {
     try{
-    const [data, animals] = await Promise.all([fetchAllData(fetch),fetchAnimals(fetch)]);
+    const [data, animals, seasons] = await Promise.all([fetchAllData(fetch),fetchAnimals(fetch), fetchSeasons(fetch)]);
 
     const storiesWithDetails = mapStoriesWithDetails(data.stories, data.audios, data.languages);
 
@@ -24,7 +24,8 @@ export async function load({ fetch }) {
         ...data,
         animals,
         stories: storiesWithDetails,
-        languages: data.languages
+        languages: data.languages,
+        seasons: seasons.seasons
     };
 } catch (err) {
     

--- a/src/routes/all-stories/+page.svelte
+++ b/src/routes/all-stories/+page.svelte
@@ -50,7 +50,9 @@
             <li>
                 <select name="season" id="season-select" aria-label="Choose a season">
                     <option value="season">Season</option>
-                    <option value="summer">Summer</option>
+                    {#each data.seasons as season}
+                        <option value="{season.id}">{season.season}</option>
+                    {/each}
                 </select>
             </li>
             <li>

--- a/src/routes/all-stories/+page.svelte
+++ b/src/routes/all-stories/+page.svelte
@@ -119,10 +119,6 @@ header,
     transform: translateX(-50%);
 }
 
-.heading-back {
-    align-self: flex-start;
-}
-
 header {
     z-index: 10;
     height: 100%;


### PR DESCRIPTION
## What does this change?

Resolves issue #233 

op de pagina /all-stories heb je meerdere knoppen waarmee je snel tussen alle verhalen kan filteren. De season-filter had eerst data wat in de html was gezet, en nog niet echt geladen werd uit de database. Dit heb ik nu aangepast zodat ik in een later issue de verhalen echt kan filteren op basis van het seizoen.

[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [x] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test
<img width="675" alt="Scherm­afbeelding 2025-03-05 om 14 25 01" src="https://github.com/user-attachments/assets/93f439a6-d14a-4608-b906-ce40db87b37e" />
<img width="710" alt="Scherm­afbeelding 2025-03-05 om 14 25 21" src="https://github.com/user-attachments/assets/7e05cbf0-60d1-4725-a679-2e23c8f23cc4" />


## Images
before 
<img width="777" alt="Scherm­afbeelding 2025-03-05 om 14 27 12" src="https://github.com/user-attachments/assets/3da1f5bb-9e4a-430b-836d-79f70dee725c" />

after
<img width="789" alt="Scherm­afbeelding 2025-03-05 om 14 27 53" src="https://github.com/user-attachments/assets/1d3e4b6c-84bd-4e71-9f17-4b3e44280566" />

## How to review
navigeer naar /lessons en klik bij all stories op "show all" nu zie je alle verhalen en de filterknoppen. als je op de season-knop klikt, zie je alle seizoenen geladen.
